### PR TITLE
Fix event handler for forecast history buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -135,7 +135,7 @@ submitButton.on("click", function () {
     combinedWeatherReport(cityName);
 })
 
-buttonsDiv.on("click", function () {
+buttonsDiv.on("click", function (event) {
     let cityName = event.target.dataset.value;
     currentWeather(cityName);
     fiveDayForecast(cityName);


### PR DESCRIPTION
## Summary
- pass event object to the forecast history button handler

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8831d4b08332ae0b54505bbb263c