### PR TITLE
Fix typos in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Developers are often tasked with retrieving data from another application's API 
 
 ## Installation
 
-This projec is an inetrenet-based app that runs inside the browser so you don't need to install anything. All you need is an internet browser to run the app. Visit the app by clicking here: https://mohammad-pishdar.github.io/Weather-Dashboard/
+This project is an internet-based app that runs inside the browser so you don't need to install anything. All you need is an internet browser to run the app. Visit the app by clicking here: https://mohammad-pishdar.github.io/Weather-Dashboard/
 
 
 ## Usage 


### PR DESCRIPTION
## Summary
- fix typos in Installation section of README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b895c3a0483328bfd9f9c9ee87316