### PR TITLE
Add alt attributes to weather icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             </div>
             <div class="col">
                 <div class="container border border-secondary rounded">
-                    <h3><span class="cityAndDate"></span><img class="weatherIcon"></h3>
+                    <h3><span class="cityAndDate"></span><img class="weatherIcon" alt="Current weather icon"></h3>
                     <p>Temperature: <span class="temperature-span"></span> &#8451;</p>
                     <p>Humidity: <span class="humidity-span"></span>%</p>
                     <p>Wind Speed: <span class="windSpeedSpan"></span> km/h</p>
@@ -51,31 +51,31 @@
                     <h4>5-Day Forecast:</h4>
                     <div class="day1Forecast float-left m-3 bg-primary text-light p-2 rounded">
                         <h5 id="day1date"></h5>
-                        <img id="day1Icon">
+                        <img id="day1Icon" alt="Forecast icon for day 1">
                         <p>Temp: <span id="day1temperature"></span> &#8451;</p>
                         <p>Humidity: <span id="day1Humidity"></span>%</p>
                     </div>
                     <div class="day2Forecast float-left m-3 bg-primary text-light p-2 rounded">
                         <h5 id="day2date"></h5>
-                        <img id="day2Icon">
+                        <img id="day2Icon" alt="Forecast icon for day 2">
                         <p>Temp: <span id="day2temperature"></span> &#8451;</p>
                         <p>Humidity: <span id="day2Humidity"></span>%</p>
                     </div>
                     <div class="day3Forecast float-left m-3 bg-primary text-light p-2 rounded">
                         <h5 id="day3date"></h5>
-                        <img id="day3Icon">
+                        <img id="day3Icon" alt="Forecast icon for day 3">
                         <p>Temp: <span id="day3temperature"></span> &#8451;</p>
                         <p>Humidity: <span id="day3Humidity"></span>%</p>
                     </div>
                     <div class="day4Forecast float-left m-3 bg-primary text-light p-2 rounded">
                         <h5 id="day4date"></h5>
-                        <img id="day4Icon">
+                        <img id="day4Icon" alt="Forecast icon for day 4">
                         <p>Temp: <span id="day4temperature"></span> &#8451;</p>
                         <p>Humidity: <span id="day4Humidity"></span>%</p>
                     </div>
                     <div class="day5Forecast float-left m-3 bg-primary text-light p-2 rounded">
                         <h5 id="day5date"></h5>
-                        <img id="day5Icon">
+                        <img id="day5Icon" alt="Forecast icon for day 5">
                         <p>Temp: <span id="day5temperature"></span> &#8451;</p>
                         <p>Humidity: <span id="day5Humidity"></span>%</p>
                     </div>


### PR DESCRIPTION
## Summary
- add descriptive alt text for current and forecast weather icons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b97769c488332910a3c444c6a7e2b